### PR TITLE
option for disabling metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Install the module with: `npm install node-xsltproc --save`
 
 - `debug` : add extra verbose message (default: false)
 - `stringparams` : add stringparam (default: {})
+- `metadata` : whether metadata should be parsed from xsltproc output (default: true)
 
 ### Exemples
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,9 @@ function XsltProcParser(output, pathPrefix) {
 
 function xsltproc(options) {
 	options = options || {};
+	if(options.metadata === undefined) {
+		options.metadata = true
+    }
 	let xsltproc_bin = path.join(options.xsltproc_path || '', 'xsltproc');
 	try {
 		let ans = execFileSync(xsltproc_bin, ['--version']);
@@ -109,7 +112,10 @@ function xsltproc(options) {
 				if (error !== null) {
 					return reject({file: filepath, message: stderr});
         	    }
-        	    let metadata = XsltProcParser(stderr, basedir);
+                let metadata;
+                if(options.metadata === true) {
+                    metadata = XsltProcParser(stderr, basedir);
+				}
             	return resolve({result: stdout, metadata: metadata});
             });
 		});


### PR DESCRIPTION
Somehow parsing the output failed for an xslt transformation but the transformation itself was successful so in order to get builds working switching metadata off was a needed capability.

Should play well with the already existing `metadata` option in the gulp plugin as metadata output will be controlled with the same option.

EDIT: just recognized an issue that undefined metadata objects cause in the gulp plugin. Fixed this also in ticapix/gulp-xsltproc#1 but we can split that fix up if you want