### PR TITLE
fix stringparams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xsltproc",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "wrapper around xsltproc with profiling information",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xsltproc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "wrapper around xsltproc with profiling information",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-xsltproc",
   "version": "1.1.3",
   "description": "wrapper around xsltproc with profiling information",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "make test"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -93,17 +93,17 @@ function xsltproc(options) {
 		return new Promise((resolve, reject) => {
 			let args = ['--load-trace', '--profile', '--output',  '-'];
 			let basedir;
+			for (let key in run_options.stringparams) {
+				let value = run_options.stringparams[key];
+				assert.equal(true, typeof value === 'string' || value instanceof String, `value of '${key}' must be a string`);
+				args = args.concat(['--stringparam', key, value]);
+			}
 			if (filepath.constructor === Array) {
 				args = args.concat(filepath);
 				basedir = path.dirname(filepath[0]);
 			} else {
 				args.push(filepath);
 				basedir = path.dirname(filepath);
-			}
-			for (let key in run_options.stringparams) {
-				let value = run_options.stringparams[key];
-				assert.equal(true, typeof value === 'string' || value instanceof String, `value of '${key}' must be a string`);
-				args = args.concat(['--stringparam', key, value]);
 			}
 			if (run_options.debug) {
 				console.log('exec:', xsltproc_bin, args.join(' '));


### PR DESCRIPTION
stringparams args must be before xsl files.

prevent this errors:
warning: failed to load external entity "--stringparam"
unable to parse --stringparam